### PR TITLE
Call correct LS endpoint for errors, propagate invoked function ARN

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-lambda-go v1.20.0


### PR DESCRIPTION
* Invoke errors are correctly returned to localstack
* Invoked function ARN is properly propagated to the function context