### PR TITLE
Fix error detection on non-map types

### DIFF
--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -117,11 +117,10 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, lo
 				var errR map[string]any
 				marshalErr := json.Unmarshal(invokeResp.Body, &errR)
 
-				if marshalErr != nil {
-					log.Fatalln(marshalErr)
+				isErr := false
+				if marshalErr == nil {
+					_, isErr = errR["errorType"]
 				}
-
-				_, isErr := errR["errorType"]
 
 				if isErr {
 					log.Infoln("Sending to /error")


### PR DESCRIPTION
Currently, if the result json does not contain a map type as json, but for example an array, boolean, number or null, runtime will panic.
This fixes this, by assuming every error returns a dict, and if its no dict, it cannot be an error.