### PR TITLE
update go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: '~1.18.2'
         
     - name: Build
       run: make compile-lambda-linux-all
       
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: aws-lambda-rie
         path: bin/*


### PR DESCRIPTION
## Motivation
Due to a security issue in golang.org/x/sys, namely [CVE-2022-29526](https://nvd.nist.gov/vuln/detail/CVE-2022-29526), an update of go is needed.

## Changes
Change the go version to 1.18.2 or higher (but <1.19). Also updated some github actions to their latest versions.