### PR TITLE
Add invocation timeout handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # LOCALSTACK CHANGES 2022-03-10: remove linker flags and add gc flags for delve debugger
 # LOCALSTACK CHANGES 2022-03-28: change compile src folder
+# LOCALSTACK CHANGES 2022-11-14: add --rm flag to compile-with-docker
 
 # RELEASE_BUILD_LINKER_FLAGS disables DWARF and symbol table generation to reduce binary size
 #RELEASE_BUILD_LINKER_FLAGS=-s -w
@@ -21,7 +22,7 @@ compile-lambda-linux-all:
 	make ARCH=arm64 compile-lambda-linux
 
 compile-with-docker:
-	docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.18 make ARCH=${ARCH} compile-lambda-linux
+	docker run --rm --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.18 make ARCH=${ARCH} compile-lambda-linux
 
 compile-lambda-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=${GO_ARCH_${ARCH}} go build -ldflags "${RELEASE_BUILD_LINKER_FLAGS}" -gcflags="all=-N -l" -o ${DESTINATION_${ARCH}} ./cmd/localstack

--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -12,7 +12,6 @@ import (
 	"go.amzn.com/lambda/rapidcore/standalone"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -53,9 +52,9 @@ type InvokeRequest struct {
 
 type ErrorResponse struct {
 	ErrorMessage string   `json:"errorMessage"`
-	ErrorType    string   `json:"errorType"`
-	RequestId    string   `json:"requestId"`
-	StackTrace   []string `json:"stackTrace"`
+	ErrorType    string   `json:"errorType,omitempty"`
+	RequestId    string   `json:"requestId,omitempty"`
+	StackTrace   []string `json:"stackTrace,omitempty"`
 }
 
 func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, logCollector *LogCollector) (server *CustomInteropServer) {
@@ -68,13 +67,6 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, lo
 			RuntimeId:        lsOpts.RuntimeId,
 		},
 	}
-	invokeTimeoutEnv := GetEnvOrDie("AWS_LAMBDA_FUNCTION_TIMEOUT")
-	invokeTimeoutSeconds, err := strconv.Atoi(invokeTimeoutEnv)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	invokeTimeout := time.Second * time.Duration(invokeTimeoutSeconds)
-	server.delegate.SetInvokeTimeout(invokeTimeout)
 
 	// TODO: extract this
 	go func() {
@@ -109,10 +101,34 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, lo
 					InvokedFunctionArn: invokeR.InvokedFunctionArn,
 					//DeadlineNs:
 				})
+				timeout := int(server.delegate.GetInvokeTimeout().Seconds())
+				isErr := false
 				if err != nil {
-					log.Fatalln(err)
+					switch err {
+					case rapidcore.ErrInvokeTimeout:
+						log.Debugf("Got invoke timeout")
+						isErr = true
+						errorResponse := ErrorResponse{
+							ErrorMessage: fmt.Sprintf(
+								"%s %s Task timed out after %d.00 seconds",
+								time.Now().Format("2006-01-02T15:04:05Z"),
+								invokeR.InvokeId,
+								timeout,
+							),
+						}
+						jsonErrorResponse, err := json.Marshal(errorResponse)
+						if err != nil {
+							log.Fatalln("unable to marshall json timeout response")
+						}
+						_, err = invokeResp.Write(jsonErrorResponse)
+						if err != nil {
+							log.Fatalln("unable to write to response")
+						}
+					default:
+						log.Fatalln(err)
+					}
 				}
-				timeoutDuration, _ := time.ParseDuration(invokeTimeoutEnv + "s")
+				timeoutDuration := time.Duration(timeout) * time.Second
 				memorySize := GetEnvOrDie("AWS_LAMBDA_FUNCTION_MEMORY_SIZE")
 				PrintEndReports(invokeR.InvokeId, "", memorySize, invokeStart, timeoutDuration, logCollector)
 
@@ -125,8 +141,7 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, lo
 				var errR map[string]any
 				marshalErr := json.Unmarshal(invokeResp.Body, &errR)
 
-				isErr := false
-				if marshalErr == nil {
+				if !isErr && marshalErr == nil {
 					_, isErr = errR["errorType"]
 				}
 

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -46,9 +46,9 @@ func main() {
 	lsOpts := InitLsOpts()
 
 	// set up logging (logrus)
-	//log.SetFormatter(&log.JSONFormatter{})
-	//log.SetLevel(log.TraceLevel)
-	log.SetLevel(log.DebugLevel)
+	log.SetFormatter(&log.JSONFormatter{})
+	log.SetLevel(log.TraceLevel)
+	//log.SetLevel(log.DebugLevel)
 	log.SetReportCaller(true)
 	// download code archive if env variable is set
 	DownloadCodeArchive(lsOpts.CodeDownloadUrl)

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -47,9 +47,9 @@ func main() {
 	lsOpts := InitLsOpts()
 
 	// set up logging (logrus)
-	log.SetFormatter(&log.JSONFormatter{})
-	log.SetLevel(log.TraceLevel)
-	//log.SetLevel(log.DebugLevel)
+	//log.SetFormatter(&log.JSONFormatter{})
+	//log.SetLevel(log.TraceLevel)
+	log.SetLevel(log.DebugLevel)
 	log.SetReportCaller(true)
 	// download code archive if env variable is set
 	DownloadCodeArchive(lsOpts.CodeDownloadUrl)


### PR DESCRIPTION
## Motivation
Currently we do not support proper timeouts for lambda functions.

## Changes
Adds proper timeout handling to the runtime init. Will report back error and restart infra if a timeout occurs.