### PR TITLE
allow arbitrary paths to be passed for hot reloading

### DIFF
--- a/cmd/localstack/awsutil.go
+++ b/cmd/localstack/awsutil.go
@@ -213,8 +213,8 @@ func resetListener(changeChannel <-chan bool, server *CustomInteropServer) {
 
 }
 
-func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, opts *LsOpts, ctx context.Context) {
-	if !opts.HotReloading {
+func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, ctx context.Context) {
+	if len(targetPaths) == 1 && targetPaths[0] == "" {
 		log.Debugln("Hot reloading disabled.")
 		return
 	}

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -11,15 +11,16 @@ import (
 	"os"
 	"runtime/debug"
 	"strconv"
+	"strings"
 )
 
 type LsOpts struct {
-	InteropPort     string
-	RuntimeEndpoint string
-	RuntimeId       string
-	InitTracingPort string
-	CodeDownloadUrl string
-	HotReloading    bool
+	InteropPort       string
+	RuntimeEndpoint   string
+	RuntimeId         string
+	InitTracingPort   string
+	CodeDownloadUrl   string
+	HotReloadingPaths []string
 }
 
 func GetEnvOrDie(env string) string {
@@ -38,8 +39,8 @@ func InitLsOpts() *LsOpts {
 		InteropPort:     GetenvWithDefault("LOCALSTACK_INTEROP_PORT", "9563"),
 		InitTracingPort: GetenvWithDefault("LOCALSTACK_RUNTIME_TRACING_PORT", "9564"),
 		// optional or empty
-		CodeDownloadUrl: os.Getenv("LOCALSTACK_CODE_ARCHIVE_DOWNLOAD_URL"),
-		HotReloading:    os.Getenv("LOCALSTACK_HOT_RELOADING_ENABLED") != "",
+		CodeDownloadUrl:   os.Getenv("LOCALSTACK_CODE_ARCHIVE_DOWNLOAD_URL"),
+		HotReloadingPaths: strings.Split(GetenvWithDefault("LOCALSTACK_HOT_RELOADING_PATHS", ""), ","),
 	}
 }
 
@@ -88,7 +89,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	go RunHotReloadingListener(interopServer, []string{"/var/task"}, lsOpts, fileWatcherContext)
+	go RunHotReloadingListener(interopServer, lsOpts.HotReloadingPaths, fileWatcherContext)
 
 	// start runtime init
 	go InitHandler(sandbox, GetEnvOrDie("AWS_LAMBDA_FUNCTION_VERSION"), int64(invokeTimeoutSeconds)) // TODO: replace this with a custom init


### PR DESCRIPTION
## Motivation
To also support layer hot reloading, we want to pass arbitrary paths to the lambda init, to allow watching for changes on arbitrary paths.

## Changes
* Instead of using a boolean value to enable hot reloading for `/var/task`, we pass a comma separated list of paths to watch. If it is empty, hot reloading will be disabled.