### PR TITLE
Switch user and drop privileges

### DIFF
--- a/cmd/localstack/awsutil.go
+++ b/cmd/localstack/awsutil.go
@@ -121,10 +121,10 @@ type Sandbox interface {
 	Invoke(responseWriter http.ResponseWriter, invoke *interop.Invoke) error
 }
 
+// GetenvWithDefault returns the value of the environment variable key or the defaultValue if key is not set
 func GetenvWithDefault(key string, defaultValue string) string {
-	envValue := os.Getenv(key)
-
-	if envValue == "" {
+	envValue, ok := os.LookupEnv(key)
+	if !ok {
 		return defaultValue
 	}
 

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -67,6 +67,10 @@ func main() {
 		uid := 993
 		gid := 990
 		AddUser(lsOpts.User, uid, gid)
+		err := os.Chown("/tmp", uid, gid)
+		if err != nil {
+			log.Errorln("Error changing owner of /tmp:", err)
+		}
 		UserLogger().Debugln("Process running as root user.")
 		DropPrivileges(lsOpts.User)
 		UserLogger().Debugln("Process running as non-root user.")

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -60,6 +60,15 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 	log.SetReportCaller(true)
 
+	// Switch to sbx user and drop root privileges
+	if IsRootUser() {
+		UserLogger().Debugln("Drop privileges and switch user.")
+		user := "sbx_user1051"
+		AddUser(user)
+		DropPrivileges(user)
+		UserLogger().Debugln("Process running as sbx user.")
+	}
+
 	// download code archive if env variable is set
 	if err := DownloadCodeArchives(lsOpts.CodeArchives); err != nil {
 		log.Fatal("Failed to download code archives")

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -67,8 +67,7 @@ func main() {
 		uid := 993
 		gid := 990
 		AddUser(lsOpts.User, uid, gid)
-		err := os.Chown("/tmp", uid, gid)
-		if err != nil {
+		if err := os.Chown("/tmp", uid, gid); err != nil {
 			log.Errorln("Error changing owner of /tmp:", err)
 		}
 		UserLogger().Debugln("Process running as root user.")

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -50,11 +50,36 @@ func InitLsOpts() *LsOpts {
 	}
 }
 
+// UnsetLsEnvs unsets environment variables specific to LocalStack to achieve better runtime parity with AWS
+func UnsetLsEnvs() {
+	unsetList := [...]string{
+		// LocalStack internal
+		"LOCALSTACK_RUNTIME_ENDPOINT",
+		"LOCALSTACK_RUNTIME_ID",
+		"LOCALSTACK_INTEROP_PORT",
+		"LOCALSTACK_RUNTIME_TRACING_PORT",
+		"LOCALSTACK_USER",
+		"LOCALSTACK_CODE_ARCHIVES",
+		"LOCALSTACK_HOT_RELOADING_PATHS",
+		"LOCALSTACK_ENABLE_DNS_SERVER",
+		// Docker container ID
+		"HOSTNAME",
+		// User
+		"HOME",
+	}
+	for _, envKey := range unsetList {
+		if err := os.Unsetenv(envKey); err != nil {
+			log.Warnln("Could not unset environment variable:", envKey, err)
+		}
+	}
+}
+
 func main() {
 	// we're setting this to the same value as in the official RIE
 	debug.SetGCPercent(33)
 
 	lsOpts := InitLsOpts()
+	UnsetLsEnvs()
 
 	// set up logging (logrus)
 	//log.SetFormatter(&log.JSONFormatter{})

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -101,7 +101,7 @@ func main() {
 		gid := 990
 		AddUser(lsOpts.User, uid, gid)
 		if err := os.Chown("/tmp", uid, gid); err != nil {
-			log.Errorln("Error changing owner of /tmp:", err)
+			log.Warnln("Could not change owner of /tmp:", err)
 		}
 		UserLogger().Debugln("Process running as root user.")
 		DropPrivileges(lsOpts.User)

--- a/cmd/localstack/user.go
+++ b/cmd/localstack/user.go
@@ -1,0 +1,111 @@
+// User utilities to create UNIX users and drop root privileges
+package main
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// AddUser adds a UNIX user (e.g., sbx_user1051) to the passwd and shadow files if not already present
+// The actual default values are based on inspecting the AWS Lambda runtime in us-east-1
+// /etc/group is empty and /etc/gshadow is not accessible in AWS
+// The home directory does not exist in AWS Lambda
+func AddUser(user string) {
+	// passwd file format: https://www.cyberciti.biz/faq/understanding-etcpasswd-file-format/
+	passwdFile := "/etc/passwd"
+	passwdEntry := fmt.Sprintf("%[1]s:x:993:990::/home/%[1]s:/sbin/nologin", user)
+	if !doesFileContainEntry(passwdFile, passwdEntry) {
+		addEntry(passwdFile, passwdEntry)
+	}
+	// shadow file format: https://www.cyberciti.biz/faq/understanding-etcshadow-file/
+	shadowFile := "/etc/shadow"
+	shadowEntry := fmt.Sprintf("%s:*:18313:0:99999:7:::", user)
+	if !doesFileContainEntry(shadowFile, shadowEntry) {
+		addEntry(shadowFile, shadowEntry)
+	}
+}
+
+// doesFileContainEntry returns true of the entry string is contained in the given file
+func doesFileContainEntry(file string, entry string) bool {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		log.Errorln("Error reading file:", file, err)
+	}
+	text := string(data)
+	return strings.Contains(text, entry)
+}
+
+// addEntry appends an entry string to the given file
+func addEntry(file string, entry string) {
+	f, err := os.OpenFile(file,
+		os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Errorln("Error opening file:", file, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(entry); err != nil {
+		log.Errorln("Error appending entry to file:", file, err)
+	}
+}
+
+// IsRootUser returns true if the current process is root and false otherwise.
+func IsRootUser() bool {
+	return os.Getuid() == 0
+}
+
+// UserLogger returns a context logger with user fields.
+func UserLogger() *log.Entry {
+	// Skip user lookup at debug level
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return log.WithFields(log.Fields{})
+	}
+	uid := os.Getuid()
+	uidString := strconv.Itoa(uid)
+	user, err := user.LookupId(uidString)
+	if err != nil {
+		log.Errorln("Error looking up user for uid:", uid, err)
+	}
+	return log.WithFields(log.Fields{
+		"username": user.Username,
+		"uid":      uid,
+		"euid":     os.Geteuid(),
+		"gid":      os.Getgid(),
+	})
+}
+
+// DropPrivileges switches to another UNIX user by dropping root privileges
+// Initially based on https://stackoverflow.com/a/75545491/6875981
+func DropPrivileges(userToSwitchTo string) {
+	// Lookup user and group IDs for the user we want to switch to.
+	userInfo, err := user.Lookup(userToSwitchTo)
+	if err != nil {
+		log.Errorln("Error looking up user:", userToSwitchTo, err)
+	}
+	// Convert group ID and user ID from string to int.
+	gid, err := strconv.Atoi(userInfo.Gid)
+	if err != nil {
+		log.Errorln("Error converting gid:", userInfo.Gid, err)
+	}
+	uid, err := strconv.Atoi(userInfo.Uid)
+	if err != nil {
+		log.Errorln("Error converting uid:", userInfo.Uid, err)
+	}
+
+	// Limitation: Debugger gets stuck when stepping over these syscalls!
+	// No breakpoints beyond this point are hit.
+	// Set group ID (real and effective).
+	err = syscall.Setgid(gid)
+	if err != nil {
+		log.Errorln("Failed to set group ID:", err)
+	}
+	// Set user ID (real and effective).
+	err = syscall.Setuid(uid)
+	if err != nil {
+		log.Errorln("Failed to set user ID:", err)
+	}
+}

--- a/cmd/localstack/user.go
+++ b/cmd/localstack/user.go
@@ -15,10 +15,10 @@ import (
 // The actual default values are based on inspecting the AWS Lambda runtime in us-east-1
 // /etc/group is empty and /etc/gshadow is not accessible in AWS
 // The home directory does not exist in AWS Lambda
-func AddUser(user string) {
+func AddUser(user string, uid int, gid int) {
 	// passwd file format: https://www.cyberciti.biz/faq/understanding-etcpasswd-file-format/
 	passwdFile := "/etc/passwd"
-	passwdEntry := fmt.Sprintf("%[1]s:x:993:990::/home/%[1]s:/sbin/nologin", user)
+	passwdEntry := fmt.Sprintf("%[1]s:x:%[2]v:%[3]v::/home/%[1]s:/sbin/nologin", user, uid, gid)
 	if !doesFileContainEntry(passwdFile, passwdEntry) {
 		addEntry(passwdFile, passwdEntry)
 	}

--- a/cmd/localstack/user.go
+++ b/cmd/localstack/user.go
@@ -34,7 +34,8 @@ func AddUser(user string, uid int, gid int) {
 func doesFileContainEntry(file string, entry string) bool {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		log.Errorln("Error reading file:", file, err)
+		log.Warnln("Could not read file:", file, err)
+		return false
 	}
 	text := string(data)
 	return strings.Contains(text, entry)
@@ -71,7 +72,7 @@ func UserLogger() *log.Entry {
 	uidString := strconv.Itoa(uid)
 	user, err := user.LookupId(uidString)
 	if err != nil {
-		log.Errorln("Error looking up user for uid:", uid, err)
+		log.Warnln("Could not look up user by uid:", uid, err)
 	}
 	return log.WithFields(log.Fields{
 		"username": user.Username,


### PR DESCRIPTION
Depends on https://github.com/localstack/lambda-runtime-init/pull/12

Switch to `sbx_user1051` user for runtime parity and drop root privileges.

# Limitations

* `DropPrivileges` breaks debugging after `syscall`. Debugging before the syscall is possible and resuming (at least) a few lines before the syscall works but stepping over the syscall or any breakpoint beyond the syscalls breaks debugging. Hence, we need to disable `DropPrivileges` for debugging:
  * Manually comment `DropPriviledges`
  * Introduce an environment variable to conditionally skip `DropPriviledges`