### PR TITLE
Report runtime init errors to localstack

### DIFF
--- a/cmd/localstack/codearchive.go
+++ b/cmd/localstack/codearchive.go
@@ -41,6 +41,7 @@ func DownloadCodeArchive(url string, targetPath string) error {
 	// create tmp directory
 	// empty string will make use of the default tmp directory
 	tmpDir, err := os.MkdirTemp("", "localstack-code-archive")
+	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -36,9 +36,9 @@ const (
 	Error LocalStackStatus = "error"
 )
 
-func (l *LocalStackAdapter) SendStatus(status LocalStackStatus) error {
+func (l *LocalStackAdapter) SendStatus(status LocalStackStatus, payload []byte) error {
 	status_url := fmt.Sprintf("%s/status/%s/%s", l.UpstreamEndpoint, l.RuntimeId, status)
-	_, err := http.Post(status_url, "text", bytes.NewReader([]byte{}))
+	_, err := http.Post(status_url, "application/json", bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate rapidcore.InteropServer, lo
 
 func (c *CustomInteropServer) StartAcceptingDirectInvokes() error {
 	log.Traceln("Function called")
-	err := c.localStackAdapter.SendStatus(Ready)
+	err := c.localStackAdapter.SendStatus(Ready, []byte{})
 	if err != nil {
 		return err
 	}
@@ -209,6 +209,10 @@ func (c *CustomInteropServer) SendResponse(invokeID string, contentType string, 
 
 func (c *CustomInteropServer) SendErrorResponse(invokeID string, response *interop.ErrorResponse) error {
 	log.Traceln("Function called")
+	err := c.localStackAdapter.SendStatus(Error, response.Payload)
+	if err != nil {
+		return err
+	}
 	return c.delegate.SendErrorResponse(invokeID, response)
 }
 

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	log "github.com/sirupsen/logrus"
 	"go.amzn.com/lambda/rapidcore"
-	_ "net/http/pprof"
 	"os"
 	"runtime/debug"
 	"strconv"


### PR DESCRIPTION
## Changes

- Fix shutdown and remove unused profiler (Previously the http server was blocking until the process was killed. Now it is properly ended after receiving a registered signal, i.e. SIGINT or SIGTERM)
- Report runtime init error back to localstack


Example for the init report arriving at localstack

```
2023-03-29T21:53:39.854 WARNING --- [   asgi_gw_1] localstack.services.awslambda.invocation.executor_endpoint : Execution environment startup failed: {"errorMessage": "ooooooh no", "errorType": "Exception", "stackTrace": ["  File \"/var/lang/lib/python3.8/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n", "  File \"/var/lang/lib/python3.8/imp.py\", line 171, in load_source\n    module = _load(spec)\n", "  File \"<frozen importlib._bootstrap>\", line 702, in _load\n", "  File \"<frozen importlib._bootstrap>\", line 671, in _load_unlocked\n", "  File \"<frozen importlib._bootstrap_external>\", line 843, in exec_module\n", "  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n", "  File \"/var/task/handler.py\", line 4, in <module>\n    raise Exception(\"ooooooh no\")\n"]}
```

The init error above is  caused by directly raising an exception outside of the python handler.