### PR TITLE
Improve logging output

### DIFF
--- a/cmd/localstack/xraydaemon.go
+++ b/cmd/localstack/xraydaemon.go
@@ -71,7 +71,8 @@ type Daemon struct {
 	server *proxy.Server
 }
 
-func initConfig(endpoint string) *cfg.Config {
+// https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-configuration.html
+func initConfig(endpoint string, logLevel string) *cfg.Config {
 	xrayConfig := cfg.DefaultConfig()
 	xrayConfig.Socket.UDPAddress = "127.0.0.1:2000"
 	xrayConfig.Socket.TCPAddress = "127.0.0.1:2000"
@@ -79,7 +80,7 @@ func initConfig(endpoint string) *cfg.Config {
 	xrayConfig.NoVerifySSL = util.Bool(true) // obvious
 	xrayConfig.LocalMode = util.Bool(true)   // skip EC2 metadata check
 	xrayConfig.Region = GetEnvOrDie("AWS_REGION")
-	xrayConfig.Logging.LogLevel = "info"
+	xrayConfig.Logging.LogLevel = logLevel
 	//xrayConfig.TotalBufferSizeMB
 	//xrayConfig.RoleARN = roleARN
 

--- a/lambda/rapi/server.go
+++ b/lambda/rapi/server.go
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // LOCALSTACK CHANGES 2022-03-10: Chi logger middleware added
+// LOCALSTACK CHANGES 2023-04-14: Replace Chi logger with the rapid AccessLogMiddleware based on Logrus
 
 package rapi
 
 import (
 	"context"
 	"fmt"
-	"github.com/go-chi/chi/middleware"
 	"net"
 	"net/http"
 
@@ -16,6 +16,7 @@ import (
 	"go.amzn.com/lambda/appctx"
 
 	"go.amzn.com/lambda/core"
+	"go.amzn.com/lambda/rapi/middleware"
 	"go.amzn.com/lambda/rapi/rendering"
 	"go.amzn.com/lambda/telemetry"
 
@@ -52,7 +53,7 @@ func NewServer(host string, port int, appCtx appctx.ApplicationContext,
 	exitErrors := make(chan error, 1)
 
 	router := chi.NewRouter()
-	router.Use(middleware.Logger)
+	router.Use(middleware.AccessLogMiddleware())
 	router.Mount(version20180601, NewRouter(appCtx, registrationService, renderingService))
 	router.Mount(version20200101, ExtensionsRouter(appCtx, registrationService, renderingService))
 


### PR DESCRIPTION
## Make init log levels configurable

Lambda container logs are very verbose such that it is hard for customers to identify what’s wrong with their Lambda implementation because the logs are mainly about RIE internals.

We already support log levels through the environment variable `LOCALSTACK_INIT_LOG_LEVEL` but only debug and trace is insufficient.

Go log levels: [https://github.com/sirupsen/logrus#level-logging](https://github.com/sirupsen/logrus#level-logging)


What should be the default level? "warn + invocation result logging"


## Follow Up

- [ ] Add invocation result logging from `PrintEndReports` (currently only sent to CloudWatch)
- [ ] Investigate / clean up warning printed upon every invocation:

```golang
2023-04-14 12:25:37 time="2023-04-14T10:25:37Z" level=warning msg="Reset initiated: SandboxTerminated" func=go.amzn.com/lambda/rapid.handleReset file="/Users/joe/Projects/LocalStack/lambda-runtime-init/lambda/rapid/start.go:589"
```
