### PR TITLE
add logging of exceptions during runtime environment create

### DIFF
--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -210,6 +210,9 @@ func (c *CustomInteropServer) SendResponse(invokeID string, contentType string, 
 
 func (c *CustomInteropServer) SendErrorResponse(invokeID string, response *interop.ErrorResponse) error {
 	is, err := c.InternalState()
+	if err != nil {
+		return err
+	}
 	rs := is.Runtime.State
 	if rs.Name == core.RuntimeInitErrorStateName {
 		err = c.localStackAdapter.SendStatus(Error, response.Payload)

--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/go-chi/chi"
 	log "github.com/sirupsen/logrus"
+	"go.amzn.com/lambda/core"
 	"go.amzn.com/lambda/core/statejson"
 	"go.amzn.com/lambda/interop"
 	"go.amzn.com/lambda/rapidcore"
@@ -208,11 +209,15 @@ func (c *CustomInteropServer) SendResponse(invokeID string, contentType string, 
 }
 
 func (c *CustomInteropServer) SendErrorResponse(invokeID string, response *interop.ErrorResponse) error {
-	log.Traceln("Function called")
-	err := c.localStackAdapter.SendStatus(Error, response.Payload)
-	if err != nil {
-		return err
+	is, err := c.InternalState()
+	rs := is.Runtime.State
+	if rs.Name == core.RuntimeInitErrorStateName {
+		err = c.localStackAdapter.SendStatus(Error, response.Payload)
+		if err != nil {
+			return err
+		}
 	}
+
 	return c.delegate.SendErrorResponse(invokeID, response)
 }
 


### PR DESCRIPTION
Avoids the `Runtime Handler can only error while starting` error logs in localstack when the invocation fails due to an error.

Previously it caused two "error reports", one via `/invocations/<invokeid>/error` and one via `/status/<runtimeid>/<status>`.