### PR TITLE
Fix filesystem permission parity

### DIFF
--- a/cmd/localstack/file_utils.go
+++ b/cmd/localstack/file_utils.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Inspired by https://stackoverflow.com/questions/73864379/golang-change-permission-os-chmod-and-os-chowm-recursively
+// but using the more efficient WalkDir API
+func ChmodRecursively(root string, mode os.FileMode) error {
+	return filepath.WalkDir(root,
+		func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			err = os.Chmod(path, mode)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+}

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -153,8 +153,12 @@ func main() {
 			log.Warnln("Could not change owner of directory /tmp:", err)
 		}
 		UserLogger().Debugln("Process running as root user.")
-		DropPrivileges(lsOpts.User)
-		UserLogger().Debugln("Process running as non-root user.")
+		err := DropPrivileges(lsOpts.User)
+		if err != nil {
+			log.Warnln("Could not drop root privileges.", err)
+		} else {
+			UserLogger().Debugln("Process running as non-root user.")
+		}
 	}
 
 	logCollector := NewLogCollector()

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -132,6 +132,11 @@ func main() {
 		log.Fatal("Failed to download code archives: " + err.Error())
 	}
 
+	// fix permissions of layers directory (if it exists) for better AWS parity
+	if err := ChmodRecursively("/opt", 0755); err != nil {
+		log.Warnln("Could not change file mode of directory /opt:", err)
+	}
+
 	// parse CLI args
 	bootstrap, handler := getBootstrap(os.Args)
 
@@ -141,7 +146,7 @@ func main() {
 		gid := 990
 		AddUser(lsOpts.User, uid, gid)
 		if err := os.Chown("/tmp", uid, gid); err != nil {
-			log.Warnln("Could not change owner of /tmp:", err)
+			log.Warnln("Could not change owner of directory /tmp:", err)
 		}
 		UserLogger().Debugln("Process running as root user.")
 		DropPrivileges(lsOpts.User)

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -132,9 +132,13 @@ func main() {
 		log.Fatal("Failed to download code archives: " + err.Error())
 	}
 
-	// fix permissions of layers directory (if it exists) for better AWS parity
+	// fix permissions of the layers directory for better AWS parity
 	if err := ChmodRecursively("/opt", 0755); err != nil {
-		log.Warnln("Could not change file mode of directory /opt:", err)
+		log.Warnln("Could not change file mode recursively of directory /opt:", err)
+	}
+	// fix permissions of the tmp directory for better AWS parity
+	if err := ChmodRecursively("/tmp", 0700); err != nil {
+		log.Warnln("Could not change file mode recursively of directory /tmp:", err)
 	}
 
 	// parse CLI args

--- a/cmd/localstack/user.go
+++ b/cmd/localstack/user.go
@@ -70,12 +70,12 @@ func UserLogger() *log.Entry {
 	}
 	uid := os.Getuid()
 	uidString := strconv.Itoa(uid)
-	user, err := user.LookupId(uidString)
+	userObject, err := user.LookupId(uidString)
 	if err != nil {
 		log.Warnln("Could not look up user by uid:", uid, err)
 	}
 	return log.WithFields(log.Fields{
-		"username": user.Username,
+		"username": userObject.Username,
 		"uid":      uid,
 		"euid":     os.Geteuid(),
 		"gid":      os.Getgid(),


### PR DESCRIPTION
## Motivation

Addresses https://github.com/localstack/localstack/issues/8897

## Changes

* Recursively change permissions for `/opt` (layers directory) to `0755`
* Recursively (?) change permissions for `/tmp` to `0700`
* Add a file utils function `ChmodRecursively`

Unrelated changes:

* Add error handling for dropping privileges
* Rename variable that shows import

## Testing

Run the test `tests.aws.services.lambda_.test_lambda.TestLambdaLayerBehavior.test_layer_permissions` in https://github.com/localstack/localstack-ext/pull/2165 against this new Go binary.
