### PR TITLE
Skip dropping privileges for root user

### DIFF
--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -145,7 +145,7 @@ func main() {
 	bootstrap, handler := getBootstrap(os.Args)
 
 	// Switch to non-root user and drop root privileges
-	if IsRootUser() && lsOpts.User != "" {
+	if IsRootUser() && lsOpts.User != "" && lsOpts.User != "root" {
 		uid := 993
 		gid := 990
 		AddUser(lsOpts.User, uid, gid)


### PR DESCRIPTION
Simplify the LocalStack configuration for skipping to drop root privileges by skipping for `LOCALSTACK_USER=root` because `LOCALSTACK_USER=""` is misleading.

As discussed in the Lambda service owner sync today.

## Testing

LocalStack changes available in branch `simplify-localstack-init-user-config`

Suitable test case: `tests.aws.services.lambda_.test_lambda.TestLambdaBehavior.test_runtime_introspection_x86`
