### PR TITLE
Set file permissions of code directory when layer present

### DIFF
--- a/cmd/localstack/file_utils.go
+++ b/cmd/localstack/file_utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -19,4 +20,20 @@ func ChmodRecursively(root string, mode os.FileMode) error {
 			}
 			return nil
 		})
+}
+
+// Check if a directory is empty
+// Source: https://stackoverflow.com/questions/30697324/how-to-check-if-directory-on-path-is-empty/30708914#30708914
+func IsDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1) // faster than f.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err // Either not empty or error, suits both cases
 }

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -132,13 +132,22 @@ func main() {
 		log.Fatal("Failed to download code archives: " + err.Error())
 	}
 
-	// fix permissions of the layers directory for better AWS parity
+	// set file permissions of the tmp directory for better AWS parity
+	if err := ChmodRecursively("/tmp", 0700); err != nil {
+		log.Warnln("Could not change file mode recursively of directory /tmp:", err)
+	}
+	// set file permissions of the layers directory for better AWS parity
 	if err := ChmodRecursively("/opt", 0755); err != nil {
 		log.Warnln("Could not change file mode recursively of directory /opt:", err)
 	}
-	// fix permissions of the tmp directory for better AWS parity
-	if err := ChmodRecursively("/tmp", 0700); err != nil {
-		log.Warnln("Could not change file mode recursively of directory /tmp:", err)
+	// set file permissions of the code directory if at least one layer is present for better AWS parity
+	// Limitation: hot reloading likely breaks file permission parity for /var/task in combination with layers
+	// Heuristic for detecting the presence of layers. It might fail for an empty layer or image-based Lambda.
+	if isDirEmpty, _ := IsDirEmpty("/opt"); !isDirEmpty {
+		log.Debugln("Detected layer present")
+		if err := ChmodRecursively("/var/task", 0755); err != nil {
+			log.Warnln("Could not change file mode recursively of directory /var/task:", err)
+		}
 	}
 
 	// parse CLI args


### PR DESCRIPTION
## Motivation

At AWS, the file permissions of the Lambda code directory `/var/task` depend on whether at least one layer is used.

* no layer: file permissions are preserved
* at least one layer: file permissions are set to `755`

This fixes sample applications on LocalStack using the [aws-lambda-web-adapter](https://github.com/awslabs/aws-lambda-web-adapter). For example: https://github.com/awslabs/aws-lambda-web-adapter/tree/main/examples/expressjs-zip

## Changes

Conditionally change the file permissions of `/var/task` if we detect that layers are present (heuristic that `/opt` is not empty).

## Testing

The branch `fix-lambda-file-permissions-with-layer` in localstack-ext provides AWS-validated tests for the two scenarios:

* with layer: `tests.aws.services.lambda_.test_lambda.TestLambdaLayerBehavior.test_file_permissions_with_layer`
* without layer: `tests.aws.services.lambda_.test_lambda.TestLambdaLayerBehavior.test_file_permissions_without_layer`