### PR TITLE
Fix macOS VirtioFS issues and hotreload/watcher performance problems

### DIFF
--- a/cmd/localstack/filenotify/filenotify.go
+++ b/cmd/localstack/filenotify/filenotify.go
@@ -32,9 +32,9 @@ func shouldUseEventWatcher() bool {
 	err := unix.Uname(&utsname)
 	release := strings.TrimRight(string(utsname.Release[:]), "\x00")
 	log.Println("Release detected: ", release)
-	// cheap check if we are in Docker desktop or not.
+	// cheap check if we are in Docker desktop for Windows (WSL2) or not.
 	// We could also inspect the mounts, but that would be more complicated and needs more parsing
-	return err == nil && !(strings.Contains(release, "linuxkit") || strings.Contains(release, "WSL2"))
+	return err == nil && !(strings.Contains(release, "WSL2"))
 }
 
 // New tries to use a fs-event watcher, and falls back to the poller if there is an error


### PR DESCRIPTION
## Summary
This pull request aims to resolve performance degradation and instability experienced on Docker Desktop for macOS, particularly when using VirtioFS file sharing and hot reloading on lambdas.

## Root Cause
The issue is traced back to the file watch mechanism, which relies on a "polling" strategy as opposed to an "event" based approach. This results in excessive CPU usage that scales proportionally with the number of files in the shared folder. This is especially problematic when the folder contains a substantial number of files due to Python dependencies.

## Changes Made
Switched from a polling-based to an event-based file watch mechanism when a linuxkit (assuming it is macOS) is detected

## Impact
These changes are expected to significantly improve performance and stability for users working with Docker Desktop on macOS, no only those utilizing VirtioFS but any other file system sharing such as "gRPC FUSE".