### PR TITLE
Allow manual specification of filewatcher behavior

### DIFF
--- a/cmd/localstack/awsutil.go
+++ b/cmd/localstack/awsutil.go
@@ -157,14 +157,14 @@ func RunDNSRewriter(opts *LsOpts, ctx context.Context) {
 	log.Debugln("DNS server stopped")
 }
 
-func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, ctx context.Context, fileWatcher string) {
+func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, ctx context.Context, fileWatcherStrategy string) {
 	if len(targetPaths) == 1 && targetPaths[0] == "" {
 		log.Debugln("Hot reloading disabled.")
 		return
 	}
 	defaultDebouncingDuration := 500 * time.Millisecond
 	log.Infoln("Hot reloading enabled, starting filewatcher.", targetPaths)
-	changeListener, err := NewChangeListener(defaultDebouncingDuration, fileWatcher)
+	changeListener, err := NewChangeListener(defaultDebouncingDuration, fileWatcherStrategy)
 	if err != nil {
 		log.Errorln("Hot reloading disabled due to change listener error.", err)
 		return

--- a/cmd/localstack/awsutil.go
+++ b/cmd/localstack/awsutil.go
@@ -157,14 +157,14 @@ func RunDNSRewriter(opts *LsOpts, ctx context.Context) {
 	log.Debugln("DNS server stopped")
 }
 
-func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, ctx context.Context) {
+func RunHotReloadingListener(server *CustomInteropServer, targetPaths []string, ctx context.Context, fileWatcher string) {
 	if len(targetPaths) == 1 && targetPaths[0] == "" {
 		log.Debugln("Hot reloading disabled.")
 		return
 	}
 	defaultDebouncingDuration := 500 * time.Millisecond
 	log.Infoln("Hot reloading enabled, starting filewatcher.", targetPaths)
-	changeListener, err := NewChangeListener(defaultDebouncingDuration)
+	changeListener, err := NewChangeListener(defaultDebouncingDuration, fileWatcher)
 	if err != nil {
 		log.Errorln("Hot reloading disabled due to change listener error.", err)
 		return

--- a/cmd/localstack/filenotify/filenotify.go
+++ b/cmd/localstack/filenotify/filenotify.go
@@ -38,19 +38,19 @@ func shouldUseEventWatcher() bool {
 }
 
 // New tries to use a fs-event watcher, and falls back to the poller if there is an error
-func New(interval time.Duration, fileWatcher string) (FileWatcher, error) {
-	if fileWatcher != "" {
-		log.Debugln("Forced usage of filewatcher: ", fileWatcher)
-		if fileWatcher == "event" {
+func New(interval time.Duration, fileWatcherStrategy string) (FileWatcher, error) {
+	if fileWatcherStrategy != "" {
+		log.Debugln("Forced usage of filewatcher strategy: ", fileWatcherStrategy)
+		if fileWatcherStrategy == "event" {
 			if watcher, err := NewEventWatcher(); err == nil {
 				return watcher, nil
 			} else {
 				log.Fatalln("Event based filewatcher is selected, but unable to start. Please try setting the filewatcher to polling. Error: ", err)
 			}
-		} else if fileWatcher == "polling" {
+		} else if fileWatcherStrategy == "polling" {
 			return NewPollingWatcher(interval), nil
 		} else {
-			log.Fatalf("Invalid filewatcher setting %s. Only event and polling are allowed.\n", fileWatcher)
+			log.Fatalf("Invalid filewatcher strategy %s. Only event and polling are allowed.\n", fileWatcherStrategy)
 		}
 	}
 	if shouldUseEventWatcher() {

--- a/cmd/localstack/filenotify/filenotify.go
+++ b/cmd/localstack/filenotify/filenotify.go
@@ -38,14 +38,28 @@ func shouldUseEventWatcher() bool {
 }
 
 // New tries to use a fs-event watcher, and falls back to the poller if there is an error
-func New(interval time.Duration) (FileWatcher, error) {
+func New(interval time.Duration, fileWatcher string) (FileWatcher, error) {
+	if fileWatcher != "" {
+		log.Debugln("Forced usage of filewatcher: ", fileWatcher)
+		if fileWatcher == "event" {
+			if watcher, err := NewEventWatcher(); err == nil {
+				return watcher, nil
+			} else {
+				log.Fatalln("Event based filewatcher is selected, but unable to start. Please try setting the filewatcher to polling. Error: ", err)
+			}
+		} else if fileWatcher == "polling" {
+			return NewPollingWatcher(interval), nil
+		} else {
+			log.Fatalf("Invalid filewatcher setting %s. Only event and polling are allowed.\n", fileWatcher)
+		}
+	}
 	if shouldUseEventWatcher() {
 		if watcher, err := NewEventWatcher(); err == nil {
-			log.Debugln("Using event based filewatcher")
+			log.Debugln("Using event based filewatcher (autodetected)")
 			return watcher, nil
 		}
 	}
-	log.Debugln("Using polling based filewatcher")
+	log.Debugln("Using polling based filewatcher (autodetected)")
 	return NewPollingWatcher(interval), nil
 }
 

--- a/cmd/localstack/hotreloading.go
+++ b/cmd/localstack/hotreloading.go
@@ -16,8 +16,8 @@ type ChangeListener struct {
 	watchedFolders     []string
 }
 
-func NewChangeListener(debouncingInterval time.Duration) (*ChangeListener, error) {
-	watcher, err := filenotify.New(200 * time.Millisecond)
+func NewChangeListener(debouncingInterval time.Duration, fileWatcher string) (*ChangeListener, error) {
+	watcher, err := filenotify.New(200*time.Millisecond, fileWatcher)
 	if err != nil {
 		log.Errorln("Cannot create change listener due to filewatcher error.", err)
 		return nil, err

--- a/cmd/localstack/hotreloading.go
+++ b/cmd/localstack/hotreloading.go
@@ -16,8 +16,8 @@ type ChangeListener struct {
 	watchedFolders     []string
 }
 
-func NewChangeListener(debouncingInterval time.Duration, fileWatcher string) (*ChangeListener, error) {
-	watcher, err := filenotify.New(200*time.Millisecond, fileWatcher)
+func NewChangeListener(debouncingInterval time.Duration, fileWatcherStrategy string) (*ChangeListener, error) {
+	watcher, err := filenotify.New(200*time.Millisecond, fileWatcherStrategy)
 	if err != nil {
 		log.Errorln("Cannot create change listener due to filewatcher error.", err)
 		return nil, err

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -20,7 +20,7 @@ type LsOpts struct {
 	User                string
 	CodeArchives        string
 	HotReloadingPaths   []string
-	FileWatcher         string
+	FileWatcherStrategy string
 	EnableDnsServer     string
 	LocalstackIP        string
 	InitLogLevel        string
@@ -51,7 +51,7 @@ func InitLsOpts() *LsOpts {
 		// optional or empty
 		CodeArchives:        os.Getenv("LOCALSTACK_CODE_ARCHIVES"),
 		HotReloadingPaths:   strings.Split(GetenvWithDefault("LOCALSTACK_HOT_RELOADING_PATHS", ""), ","),
-		FileWatcher:         os.Getenv("LOCALSTACK_FILE_WATCHER"),
+		FileWatcherStrategy: os.Getenv("LOCALSTACK_FILE_WATCHER_STRATEGY"),
 		EnableDnsServer:     os.Getenv("LOCALSTACK_ENABLE_DNS_SERVER"),
 		EnableXRayTelemetry: os.Getenv("LOCALSTACK_ENABLE_XRAY_TELEMETRY"),
 		LocalstackIP:        os.Getenv("LOCALSTACK_HOSTNAME"),
@@ -227,7 +227,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	go RunHotReloadingListener(interopServer, lsOpts.HotReloadingPaths, fileWatcherContext, lsOpts.FileWatcher)
+	go RunHotReloadingListener(interopServer, lsOpts.HotReloadingPaths, fileWatcherContext, lsOpts.FileWatcherStrategy)
 
 	// start runtime init. It is important to start `InitHandler` synchronously because we need to ensure the
 	// notification channels and status fields are properly initialized before `AwaitInitialized`

--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -20,6 +20,7 @@ type LsOpts struct {
 	User                string
 	CodeArchives        string
 	HotReloadingPaths   []string
+	FileWatcher         string
 	EnableDnsServer     string
 	LocalstackIP        string
 	InitLogLevel        string
@@ -50,6 +51,7 @@ func InitLsOpts() *LsOpts {
 		// optional or empty
 		CodeArchives:        os.Getenv("LOCALSTACK_CODE_ARCHIVES"),
 		HotReloadingPaths:   strings.Split(GetenvWithDefault("LOCALSTACK_HOT_RELOADING_PATHS", ""), ","),
+		FileWatcher:         os.Getenv("LOCALSTACK_FILE_WATCHER"),
 		EnableDnsServer:     os.Getenv("LOCALSTACK_ENABLE_DNS_SERVER"),
 		EnableXRayTelemetry: os.Getenv("LOCALSTACK_ENABLE_XRAY_TELEMETRY"),
 		LocalstackIP:        os.Getenv("LOCALSTACK_HOSTNAME"),
@@ -225,7 +227,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	go RunHotReloadingListener(interopServer, lsOpts.HotReloadingPaths, fileWatcherContext)
+	go RunHotReloadingListener(interopServer, lsOpts.HotReloadingPaths, fileWatcherContext, lsOpts.FileWatcher)
 
 	// start runtime init. It is important to start `InitHandler` synchronously because we need to ensure the
 	// notification channels and status fields are properly initialized before `AwaitInitialized`


### PR DESCRIPTION
## Motivation
As seen with PR #28, there are some performance problems with the polling filewatcher.

It seems, that in newer macos versions, we have fsnotify events available as well. However, to avoid a braking change, and until we can verify what docker desktop version and which settings enable this, we are for now introducing an environment variable so users can manually override the automatic decision.

This will also be useful once we change the default behavior (e.g. with #28), to give users an option to go back to the current behavior.

## Changes
* Introduce new `LOCALSTACK_FILE_WATCHER_STRATEGY` config, with to possible options: `event` and `polling`. Event uses file system events, polling our poller like currently on Docker Desktop. Specifying this option will override the default handling, if it is empty, the current behavior is preserved. If set to something other than `event` or `polling`, the init binary will crash to indicate an incorrect configuration.