### PR TITLE
Add new localstack tracer to return tracing headers set by invoke

### DIFF
--- a/cmd/localstack/main.go
+++ b/cmd/localstack/main.go
@@ -178,6 +178,7 @@ func main() {
 
 	logCollector := NewLogCollector()
 	localStackLogsEgressApi := NewLocalStackLogsEgressAPI(logCollector)
+	tracer := NewLocalStackTracer()
 
 	// build sandbox
 	sandbox := rapidcore.
@@ -191,7 +192,8 @@ func main() {
 		}).
 		SetExtensionsFlag(true).
 		SetInitCachingFlag(true).
-		SetLogsEgressAPI(localStackLogsEgressApi)
+		SetLogsEgressAPI(localStackLogsEgressApi).
+		SetTracer(tracer)
 
 	// xray daemon
 	endpoint := "http://" + lsOpts.LocalstackIP + ":" + lsOpts.EdgePort

--- a/cmd/localstack/tracer.go
+++ b/cmd/localstack/tracer.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"go.amzn.com/lambda/appctx"
+	"go.amzn.com/lambda/interop"
+)
+
+type LocalStackTracer struct {
+	invoke *interop.Invoke
+}
+
+func (t *LocalStackTracer) Configure(invoke *interop.Invoke) {
+	t.invoke = invoke
+}
+
+func (t *LocalStackTracer) CaptureInvokeSegment(ctx context.Context, criticalFunction func(context.Context) error) error {
+	return criticalFunction(ctx)
+}
+
+func (t *LocalStackTracer) CaptureInitSubsegment(ctx context.Context, criticalFunction func(context.Context) error) error {
+	return criticalFunction(ctx)
+}
+
+func (t *LocalStackTracer) CaptureInvokeSubsegment(ctx context.Context, criticalFunction func(context.Context) error) error {
+	return criticalFunction(ctx)
+}
+
+func (t *LocalStackTracer) CaptureOverheadSubsegment(ctx context.Context, criticalFunction func(context.Context) error) error {
+	return criticalFunction(ctx)
+}
+
+func (t *LocalStackTracer) RecordInitStartTime()                                             {}
+func (t *LocalStackTracer) RecordInitEndTime()                                               {}
+func (t *LocalStackTracer) SendInitSubsegmentWithRecordedTimesOnce(ctx context.Context)      {}
+func (t *LocalStackTracer) SendRestoreSubsegmentWithRecordedTimesOnce(ctx context.Context)   {}
+func (t *LocalStackTracer) MarkError(ctx context.Context)                                    {}
+func (t *LocalStackTracer) AttachErrorCause(ctx context.Context, errorCause json.RawMessage) {}
+
+func (t *LocalStackTracer) WithErrorCause(ctx context.Context, appCtx appctx.ApplicationContext, criticalFunction func(ctx context.Context) error) func(ctx context.Context) error {
+	return criticalFunction
+}
+func (t *LocalStackTracer) WithError(ctx context.Context, appCtx appctx.ApplicationContext, criticalFunction func(ctx context.Context) error) func(ctx context.Context) error {
+	return criticalFunction
+}
+func (t *LocalStackTracer) BuildTracingHeader() func(context.Context) string {
+	// extract root trace ID and parent from context and build the tracing header
+	return func(ctx context.Context) string {
+		return t.invoke.TraceID
+	}
+}
+
+func (t *LocalStackTracer) BuildTracingCtxForStart() *interop.TracingCtx {
+	return nil
+}
+func (t *LocalStackTracer) BuildTracingCtxAfterInvokeComplete() *interop.TracingCtx {
+	return nil
+}
+
+func NewLocalStackTracer() *LocalStackTracer {
+	return &LocalStackTracer{}
+}


### PR DESCRIPTION
## Motivation

With the latest release, due to changes in the upstream code, the tracing id was not sent to the runtime interface clients as expected.
Due to the interface changes, returning the trace id sent in the invoke id was directly possible anymore, which is why we need to set the invoke struct into the tracer on every "configure" call (happens on every invoke), which we can then use to return the trace ID again.

## Changes

* Add new LocalStack tracer that replaces the NoopTracer and takes the tracing header from the invoke payload