### PR TITLE
Update go version in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '~1.18.2'
+        go-version: '1.20'
         
     - name: Build
       env:
         RELEASE_BUILD_LINKER_FLAGS: "-s -w"
       run: make compile-lambda-linux-all
       
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: aws-lambda-rie
         path: bin/*


### PR DESCRIPTION
## Motivation
We are still building the init with go 1.18 in the github actions, but bumped our go version to 1.20 with the recent pull of the upstream changes.

## Changes
* Update versions of Github Actions `checkout` and `setup-go`
* Bump go version to 1.20