### PR TITLE
Fix oversized response handling

### DIFF
--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/go-chi/chi"
 	log "github.com/sirupsen/logrus"
@@ -117,8 +118,8 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate interop.Server, logCollecto
 				timeout := int(server.delegate.GetInvokeTimeout().Seconds())
 				isErr := false
 				if err != nil {
-					switch err {
-					case rapidcore.ErrInvokeTimeout:
+					switch {
+					case errors.Is(err, rapidcore.ErrInvokeTimeout):
 						log.Debugf("Got invoke timeout")
 						isErr = true
 						errorResponse := ErrorResponse{
@@ -137,6 +138,8 @@ func NewCustomInteropServer(lsOpts *LsOpts, delegate interop.Server, logCollecto
 						if err != nil {
 							log.Fatalln("unable to write to response")
 						}
+					case errors.Is(err, rapidcore.ErrInvokeDoneFailed):
+						// we can actually just continue here, error message is sent below
 					default:
 						log.Fatalln(err)
 					}

--- a/debugging/Makefile
+++ b/debugging/Makefile
@@ -1,5 +1,5 @@
 # Golang EOL overview: https://endoflife.date/go
-DOCKER_GOLANG_IMAGE ?= golang:1.21.0-bullseye
+DOCKER_GOLANG_IMAGE ?= golang:1.20-bullseye
 
 # On ARM hosts, use: make ARCH=arm64 build-init
 # Check host architecture: uname -m

--- a/debugging/Makefile
+++ b/debugging/Makefile
@@ -1,5 +1,5 @@
 # Golang EOL overview: https://endoflife.date/go
-DOCKER_GOLANG_IMAGE ?= golang:1.19
+DOCKER_GOLANG_IMAGE ?= golang:1.21.0-bullseye
 
 # On ARM hosts, use: make ARCH=arm64 build-init
 # Check host architecture: uname -m

--- a/lambda/core/directinvoke/directinvoke.go
+++ b/lambda/core/directinvoke/directinvoke.go
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+// LOCALSTACK CHANGES 2024-02-13: casting of MaxPayloadSize
 
 package directinvoke
 
@@ -51,7 +52,7 @@ var ResetReasonMap = map[string]fatalerror.ErrorType{
 	"timeout": fatalerror.SandboxTimeout,
 }
 
-var MaxDirectResponseSize int64 = interop.MaxPayloadSize // this is intentionally not a constant so we can configure it via CLI
+var MaxDirectResponseSize = int64(interop.MaxPayloadSize) // this is intentionally not a constant so we can configure it via CLI
 var ResponseBandwidthRate int64 = interop.ResponseBandwidthRate
 var ResponseBandwidthBurstSize int64 = interop.ResponseBandwidthBurstSize
 
@@ -104,7 +105,7 @@ func ReceiveDirectInvoke(w http.ResponseWriter, r *http.Request, token interop.T
 
 	now := metering.Monotime()
 
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 	if maxPayloadSize := r.Header.Get(MaxPayloadSizeHeader); maxPayloadSize != "" {
 		if n, err := strconv.ParseInt(maxPayloadSize, 10, 64); err == nil && n >= -1 {
 			MaxDirectResponseSize = n

--- a/lambda/interop/model.go
+++ b/lambda/interop/model.go
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-// LOCALSTACK CHANGES 2024-02-13: adjust error message for ErrorResponseTooLarge to be in parity with what AWS returns
+// LOCALSTACK CHANGES 2024-02-13: adjust error message for ErrorResponseTooLarge to be in parity with what AWS returns; make MaxPayloadSize adjustable
 
 package interop
 
@@ -19,10 +19,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var MaxPayloadSize int = 6*1024*1024 + 100 // 6 MiB + 100 bytes
+
 // MaxPayloadSize max event body size declared as LAMBDA_EVENT_BODY_SIZE
 const (
-	MaxPayloadSize = 6*1024*1024 + 100 // 6 MiB + 100 bytes
-
 	ResponseBandwidthRate      = 2 * 1024 * 1024 // default average rate of 2 MiB/s
 	ResponseBandwidthBurstSize = 6 * 1024 * 1024 // default burst size of 6 MiB
 

--- a/lambda/interop/model.go
+++ b/lambda/interop/model.go
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+// LOCALSTACK CHANGES 2024-02-13: adjust error message for ErrorResponseTooLarge to be in parity with what AWS returns
 
 package interop
 
@@ -355,7 +356,7 @@ type ErrorResponseTooLargeDI struct {
 
 // ErrorResponseTooLarge is returned when response provided by Runtime does not fit into shared memory buffer
 func (s *ErrorResponseTooLarge) Error() string {
-	return fmt.Sprintf("Response payload size (%d bytes) exceeded maximum allowed payload size (%d bytes).", s.ResponseSize, s.MaxResponseSize)
+	return fmt.Sprintf("Response payload size exceeded maximum allowed payload size (%d bytes).", s.MaxResponseSize)
 }
 
 // AsErrorResponse generates ErrorInvokeResponse from ErrorResponseTooLarge

--- a/lambda/rapi/rendering/rendering.go
+++ b/lambda/rapi/rendering/rendering.go
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+// LOCALSTACK CHANGES 2024-02-13: casting of MaxPayloadSize
 
 package rendering
 
@@ -174,7 +175,7 @@ func (s *InvokeRenderer) bufferInvokeRequest() error {
 	defer s.requestMutex.Unlock()
 	var err error = nil
 	if s.requestBuffer.Len() == 0 {
-		reader := io.LimitReader(s.invoke.Payload, interop.MaxPayloadSize)
+		reader := io.LimitReader(s.invoke.Payload, int64(interop.MaxPayloadSize))
 		start := time.Now()
 		_, err = s.requestBuffer.ReadFrom(reader)
 		s.metrics = InvokeRendererMetrics{


### PR DESCRIPTION
When sending an oversized (>6MB) response payload, the runtime process exits with exit code 1. In our error handling code we used `log.Fatal` when handling a `ErrInvokeDoneFailed` exception which caused the init to prematurely exit and thus didn't send a proper response back to localstack.

Additionaly when testing, I've noticed a small parity gap, so I patched the generated message to not include the actual bytes there. Though I guess its debatable if we want to keep that part of the PR or not. :man_shrugging: 