### PR TITLE
Pull upstream changes into main, upgrade go to 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.24'
         
     - name: Build
       env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add default reviewers for community PRs
+* @dfangl @joe4dev @gregfurman @dominikschubert

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DESTINATION_old:= bin/${BINARY_NAME}
 DESTINATION_x86_64 := bin/${BINARY_NAME}-x86_64
 DESTINATION_arm64 := bin/${BINARY_NAME}-arm64
 
-run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.22 $(1)
+run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.24 $(1)
 
 compile-with-docker-all:
 	$(call run_in_docker, make compile-lambda-linux-all)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com
 
-go 1.22
+go 1.24
 
 require (
 	github.com/aws/aws-lambda-go v1.46.0

--- a/lambda/rapi/handler/agentnext.go
+++ b/lambda/rapi/handler/agentnext.go
@@ -48,7 +48,7 @@ func (h *agentNextHandler) ServeHTTP(writer http.ResponseWriter, request *http.R
 		}
 	} else {
 		log.Warnf("Unknown agent %s tried to call /next", agentID.String())
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension"+agentID.String())
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension %s", agentID.String())
 		return
 	}
 

--- a/lambda/rapi/handler/agentregister.go
+++ b/lambda/rapi/handler/agentregister.go
@@ -77,7 +77,7 @@ func (h *agentRegisterHandler) ServeHTTP(writer http.ResponseWriter, request *ht
 
 	registerRequest, err := parseRegister(request)
 	if err != nil {
-		rendering.RenderForbiddenWithTypeMsg(writer, request, errInvalidRequestFormat, err.Error())
+		rendering.RenderForbiddenWithTypeMsg(writer, request, errInvalidRequestFormat, "%s", err.Error())
 		return
 	}
 

--- a/lambda/rapi/handler/runtimelogs.go
+++ b/lambda/rapi/handler/runtimelogs.go
@@ -30,7 +30,7 @@ func (h *runtimeLogsHandler) ServeHTTP(writer http.ResponseWriter, request *http
 		log.Errorf("Agent Verification Error: %s", err)
 		switch err := err.(type) {
 		case *ErrAgentIdentifierUnknown:
-			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension "+err.agentID.String())
+			rendering.RenderForbiddenWithTypeMsg(writer, request, errAgentIdentifierUnknown, "Unknown extension %s", err.agentID.String())
 			h.telemetrySubscription.RecordCounterMetric(telemetry.SubscribeClientErr, 1)
 		default:
 			rendering.RenderInternalServerError(writer, request)
@@ -55,7 +55,7 @@ func (h *runtimeLogsHandler) ServeHTTP(writer http.ResponseWriter, request *http
 		switch err {
 		case telemetry.ErrTelemetryServiceOff:
 			rendering.RenderForbiddenWithTypeMsg(writer, request,
-				h.telemetrySubscription.GetServiceClosedErrorType(), h.telemetrySubscription.GetServiceClosedErrorMessage())
+				h.telemetrySubscription.GetServiceClosedErrorType(), "%s", h.telemetrySubscription.GetServiceClosedErrorMessage())
 			h.telemetrySubscription.RecordCounterMetric(telemetry.SubscribeClientErr, 1)
 		default:
 			rendering.RenderInternalServerError(writer, request)

--- a/lambda/rapid/handlers.go
+++ b/lambda/rapid/handlers.go
@@ -243,7 +243,7 @@ func (c *rapidContext) watchEvents(events <-chan supvmodel.Event) {
 				if termination.Success() {
 					err = fmt.Errorf("exit code 0")
 				} else {
-					err = fmt.Errorf(termination.String())
+					err = fmt.Errorf("%s", termination.String())
 				}
 
 				appctx.StoreFirstFatalError(c.appCtx, fatalerror.AgentCrash)
@@ -851,7 +851,7 @@ func handleRestore(execCtx *rapidContext, restore *interop.Restore) (interop.Res
 	// check if there is any error stored in appctx to get the root cause error type
 	// Runtime.ExitError is an example to such a scenario
 	if fatalErrorFound {
-		err = fmt.Errorf(string(fatalErrorType))
+		err = fmt.Errorf("%s", string(fatalErrorType))
 	}
 
 	if err != nil {

--- a/test/integration/local_lambda/test_end_to_end.py
+++ b/test/integration/local_lambda/test_end_to_end.py
@@ -173,9 +173,8 @@ class TestEndToEnd(TestCase):
         with self.create_container(params, image):
             r = self.invoke_function()
         
-            # Execution time is not decided, 1.0s ~ 3.0s is a good estimation
-            self.assertLess(int(r.content), 3000)
-            self.assertGreater(int(r.content), 1000)
+            # Execution time is not decided, but it should be around 2.0s
+            self.assertAround(int(r.content), 2000)
 
 
     def test_context_get_remaining_time_in_ten_seconds(self):
@@ -186,9 +185,8 @@ class TestEndToEnd(TestCase):
         with self.create_container(params, image):
             r = self.invoke_function()
         
-            # Execution time is not decided, 8.0s ~ 10.0s is a good estimation
-            self.assertLess(int(r.content), 10000)
-            self.assertGreater(int(r.content), 8000)
+            # Execution time is not decided, but it should be around 9.0s
+            self.assertAround(int(r.content), 9000)
 
 
     def test_context_get_remaining_time_in_default_deadline(self):
@@ -199,9 +197,8 @@ class TestEndToEnd(TestCase):
         with self.create_container(params, image):
             r = self.invoke_function()
 
-            # Executation time is not decided, 298.0s ~ 300.0s is a good estimation
-            self.assertLess(int(r.content), 300000)
-            self.assertGreater(int(r.content), 298000)
+            # Execution time is not decided, but it should be around 299.0s
+            self.assertAround(int(r.content), 299000)
 
 
     def test_invoke_with_pre_runtime_api_runtime(self):
@@ -256,6 +253,13 @@ class TestEndToEnd(TestCase):
             self.assertEqual("bar", content["foo"])
             self.assertEqual(123, content["baz"])
 
+    def assertAround(self, number, target):
+        # Emulating arm64 on x86 causes the invoke to take longer
+        delay_arm64 = 500
+        actual_target = target if self.ARCH != 'arm64' else target - delay_arm64
+
+        self.assertLess(number, actual_target + 1000)
+        self.assertGreater(number, actual_target - 1000)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Motivation
The official AWS lambda-runtime-init received some upstream updates. We should update our customized localstack version to include these updates (e.g., the new Golang version).


## Changes
* I added a CODEOWNERS file to this repository to automatically request reviews from lambda service owners for new PRs (to avoid a PR being lost like #38)
* Update to go 1.24
* Some changes to upstream testing (not relevant for us)
