### PR TITLE
fix: Ensure the LambdaRuntimeAPI server is up before launching INIT phase

### DIFF
--- a/cmd/localstack/custom_interop.go
+++ b/cmd/localstack/custom_interop.go
@@ -8,17 +8,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/go-chi/chi"
 	log "github.com/sirupsen/logrus"
 	"go.amzn.com/lambda/core/statejson"
 	"go.amzn.com/lambda/interop"
 	"go.amzn.com/lambda/rapidcore"
 	"go.amzn.com/lambda/rapidcore/standalone"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type CustomInteropServer struct {

--- a/cmd/localstack/runtime.go
+++ b/cmd/localstack/runtime.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func waitForRuntimeAPI(ctx context.Context, targetAddress string) error {
+	if !strings.HasPrefix(targetAddress, "http://") {
+		targetAddress = fmt.Sprintf("http://%s", targetAddress)
+	}
+
+	healthEndpoint, err := url.JoinPath(targetAddress, "2018-06-01", "ping")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthEndpoint, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		resp, err := client.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/cmd/localstack/runtime.go
+++ b/cmd/localstack/runtime.go
@@ -27,7 +27,7 @@ func waitForRuntimeAPI(ctx context.Context, targetAddress string) error {
 		Timeout: 5 * time.Second,
 	}
 
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
## Motivation

- Fixes a race condition where the Lambda runtime API server has not yet started up, yet we try to initiate an INIT request.
- Addresses issue in LocalStack community: https://github.com/localstack/localstack/issues/12680

## Changes
- Adds a `waitForRuntimeAPI` helper function that checks the `/ping` endpoint of the runtime API server before allowing the `INIT` functionality to proceed.

