### PR TITLE
fix(vulnerability): upgrade to go 1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         
     - name: Build
       env:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO_ARCH_arm64 := arm64
 DESTINATION_x86_64 := bin/${BINARY_NAME}-x86_64
 DESTINATION_arm64 := bin/${BINARY_NAME}-arm64
 
-run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.24 $(1)
+run_in_docker = docker run --env GOPROXY=direct -v $(shell pwd):/LambdaRuntimeLocal -w /LambdaRuntimeLocal golang:1.25 $(1)
 
 compile-with-docker-all:
 	$(call run_in_docker, make compile-lambda-linux-all)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.amzn.com
 
-go 1.24
+go 1.25
 
 require (
 	github.com/aws/aws-lambda-go v1.46.0


### PR DESCRIPTION
Some vulnerabilities were detected in the `stdlib` lib of go version `v1.24.7` see https://linear.app/localstack/issue/ENG-115/2025-11-05-detected-security-vulnerabilities. This PR upgrades go to latest version.