### PR TITLE
Fix tests and run tests on ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -18,7 +18,21 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
-        
+
+    - name: Run tests
+      run: make tests
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+
     - name: Build
       env:
         RELEASE_BUILD_LINKER_FLAGS: "-s -w"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         go-version: '1.25'
 
     - name: Run tests
-      run: make tests
+      run: make tests-with-docker
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -1,10 +1,10 @@
 name: Run Integration Tests
 
-on:
-  pull_request:
-    branches:
-      - develop
-
+# on:
+#   pull_request:
+#     branches:
+#       - develop
+#
 jobs:
   go-tests:
     runs-on: ubuntu-latest

--- a/lambda/core/directinvoke/directinvoke_test.go
+++ b/lambda/core/directinvoke/directinvoke_test.go
@@ -119,7 +119,7 @@ func TestAsyncPayloadCopyWhenPayloadSizeBelowMaxAllowed(t *testing.T) {
 	require.Equal(t, EndOfResponseComplete, writer.Header().Get(EndOfResponseTrailer))
 
 	// reset it to its original value
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 func TestAsyncPayloadCopyWhenPayloadSizeEqualMaxAllowed(t *testing.T) {
@@ -138,7 +138,7 @@ func TestAsyncPayloadCopyWhenPayloadSizeEqualMaxAllowed(t *testing.T) {
 	require.Equal(t, EndOfResponseComplete, writer.Header().Get(EndOfResponseTrailer))
 
 	// reset it to its original value
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 func TestAsyncPayloadCopyWhenPayloadSizeAboveMaxAllowed(t *testing.T) {
@@ -163,7 +163,7 @@ func TestAsyncPayloadCopyWhenPayloadSizeAboveMaxAllowed(t *testing.T) {
 	require.Equal(t, EndOfResponseOversized, writer.Header().Get(EndOfResponseTrailer))
 
 	// reset it to its original value
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 // This is only allowed in streaming mode, currently.
@@ -183,7 +183,7 @@ func TestAsyncPayloadCopyWhenUnlimitedPayloadSizeAllowed(t *testing.T) {
 	require.Equal(t, EndOfResponseComplete, writer.Header().Get(EndOfResponseTrailer))
 
 	// reset it to its original value
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 // We use an interruptable response writer which informs on a channel that it's ready to be interrupted after
@@ -275,7 +275,7 @@ func TestSendPayloadLimitedResponseWithinThresholdWithStreamingFunction(t *testi
 	<-testFinished
 
 	// Reset to its default value, just in case other tests use them
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 func TestSendPayloadLimitedResponseAboveThresholdWithStreamingFunction(t *testing.T) {
@@ -310,7 +310,7 @@ func TestSendPayloadLimitedResponseAboveThresholdWithStreamingFunction(t *testin
 	<-testFinished
 
 	// Reset to its default value, just in case other tests use them
-	MaxDirectResponseSize = interop.MaxPayloadSize
+	MaxDirectResponseSize = int64(interop.MaxPayloadSize)
 }
 
 func TestSendStreamingInvokeResponseSuccessWithTrailers(t *testing.T) {

--- a/lambda/interop/model.go
+++ b/lambda/interop/model.go
@@ -356,7 +356,7 @@ type ErrorResponseTooLargeDI struct {
 
 // ErrorResponseTooLarge is returned when response provided by Runtime does not fit into shared memory buffer
 func (s *ErrorResponseTooLarge) Error() string {
-	return fmt.Sprintf("Response payload size exceeded maximum allowed payload size (%d bytes).", s.MaxResponseSize)
+	return fmt.Sprintf("Response payload size (%d bytes) exceeded maximum allowed payload size (%d bytes).", s.ResponseSize, s.MaxResponseSize)
 }
 
 // AsErrorResponse generates ErrorInvokeResponse from ErrorResponseTooLarge


### PR DESCRIPTION
1. Fixed the failing unit tests and type check:

```
--- FAIL: TestResponseTooLarge (0.01s)
    invocationresponse_test.go:67:
        	Error Trace:	/home/carolavillo/Workspaces/localstack/lambda-runtime-init/lambda/rapi/handler/invocationresponse_test.go:67
        	Error:      	Not equal:
        	            	expected: "Response payload size (6291557 bytes) exceeded maximum allowed payload size (6291556 bytes)."
        	            	actual  : "Response payload size exceeded maximum allowed payload size (6291556 bytes)."
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-Response payload size (6291557 bytes) exceeded maximum allowed payload size (6291556 bytes).
        	            	+Response payload size exceeded maximum allowed payload size (6291556 bytes).
        	Test:       	TestResponseTooLarge
```
```
lambda/core/directinvoke/customerheaders.go:1: : # go.amzn.com/lambda/core/directinvoke [go.amzn.com/lambda/core/directinvoke.test]
lambda/core/directinvoke/directinvoke_test.go:122:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment
lambda/core/directinvoke/directinvoke_test.go:141:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment
lambda/core/directinvoke/directinvoke_test.go:166:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment
lambda/core/directinvoke/directinvoke_test.go:186:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment
lambda/core/directinvoke/directinvoke_test.go:278:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment
lambda/core/directinvoke/directinvoke_test.go:313:26: cannot use interop.MaxPayloadSize (variable of type int) as int64 value in assignment (typecheck)
```

2. Added Github job to run unit tests 
