### PR TITLE
update link to LocalStack for AWS in README

### DIFF
--- a/README-LOCALSTACK.md
+++ b/README-LOCALSTACK.md
@@ -1,6 +1,6 @@
 # Customized lambda-runtime-init for LocalStack
 
-This customized version of the Lambda Runtime Interface Emulator (RIE) is designed to work with [LocalStack](https://github.com/localstack/localstack).
+This customized version of the Lambda Runtime Interface Emulator (RIE) is designed to work with [LocalStack for AWS](https://www.localstack.cloud/localstack-for-aws)).
 
 Refer to [debugging/README.md](./debugging/README.md) for instructions on how to build and test the customized RIE with LocalStack.
 


### PR DESCRIPTION
## Motivation
With the [upcoming changes](https://blog.localstack.cloud/the-road-ahead-for-localstack/) to consolidate the emulator images, the Community repo linked in the README will not be the primary point of contact anymore. This PR updates the link in the README to link towards our website instead.

Fixes ENG-400

## Changes
- Update the README to link towards the website instead of the GitHub repo.