### PR TITLE
Reconfigure renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,31 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+      "groupName": "Go toolchain"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["go"],
+      "groupName": "Go toolchain"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "excludePackageNames": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go dependencies (non-major)"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "excludePackageNames": ["go"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Go dependencies (major)"
+    }
   ]
 }


### PR DESCRIPTION
We were previously using the default renovate config which opens one PR per dependency (noisy).

### Changes

This PR groups minor and patch dependency updates and explicitly enables go version updates:

| PR group | Covers |
|---|---|
| `Go toolchain` | `go` directive in `go.mod` + `go-version` in GitHub Actions workflows |
| `Go dependencies (non-major)` | minor and patch go module updates |
| `Go dependencies (major)` | major go module updates |


Run `go mod tidy` automatically for each PR.

closes DRG-549
