### PR TITLE
chore: disable major Go dependency updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
       "matchManagers": ["gomod"],
       "excludePackageNames": ["go"],
       "matchUpdateTypes": ["major"],
-      "groupName": "Go dependencies (major)"
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Disables Renovate PRs for major Go module version bumps

## Context

Major Go module upgrades require changing import paths throughout the source code (e.g. `github.com/go-chi/chi` → `github.com/go-chi/chi/v5`), which Renovate cannot do automatically. The resulting PRs only update `go.mod`/`go.sum` but leave the source code on the old import paths, making them incomplete and misleading (e.g. #86).

Disabling these makes major upgrades an intentional manual process, which they have to be anyway.