### PR TITLE
Add timeout to RC release workflow

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -25,6 +25,8 @@ jobs:
   rc-release:
     if: github.event.action == 'labeled' && github.event.label.name == 'trigger:rc-release'
     runs-on: ubuntu-latest
+    # Builds typically finish in ~3 min; cap well above that to fail fast on a hang.
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -87,6 +89,8 @@ jobs:
   cleanup:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    # Just a few gh API calls; should complete in seconds.
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
We should add explicit timeouts to the RC release workflow to avoid hitting the way-too-long default 6h timeout.